### PR TITLE
Added `random` package

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: 'dburles:factory',
   summary: 'Factories for Meteor',
-  version: "0.3.9",
+  version: "0.3.10",
   git: "https://github.com/percolatestudio/meteor-factory.git"
 });
 
 Package.on_use(function(api) {
   api.versionsFrom("METEOR@0.9.0");
-  api.use(['minimongo', 'underscore', 'ejson']);
+  api.use(['minimongo', 'underscore', 'ejson', 'random']);
   api.add_files('lib/factory.js', ['client', 'server']);
   api.export('Factory', ['client', 'server']);
 });


### PR DESCRIPTION
When using this package on the server an error is thrown `ReferenceError: Random is not defined`. This fixes that.